### PR TITLE
Update linux lsblk implementation to correctly deserialise output on Ubuntu 22.02

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,3 +26,4 @@ serde = { version = "1.0", features = ["derive"] }
 [target.'cfg(target_os = "linux")'.dependencies]
 serde = { version = "1.0", features = ["derive"] }
 serde_json = { version = "1.0" }
+serde_with = { version = "3.14.0" }

--- a/src/pal/linux.rs
+++ b/src/pal/linux.rs
@@ -2,6 +2,7 @@ use std::process::Command;
 
 use crate::device::{DeviceDescriptor, MountPoint};
 use serde::Deserialize;
+use serde_with::{DisplayFromStr, serde_as};
 
 #[derive(Deserialize, Debug)]
 struct Devices {
@@ -47,6 +48,7 @@ impl Device {
 
     fn description(&self) -> String {
         [
+            self.name.as_ref(),
             self.label.as_deref().unwrap_or_default(),
             self.vendor.as_deref().unwrap_or_default(),
             self.model.as_deref().unwrap_or_default(),
@@ -96,11 +98,13 @@ impl From<Device> for DeviceDescriptor {
         }
     }
 }
-
+#[serde_as]
 #[derive(Deserialize, Debug)]
 struct Child {
     mountpoint: Option<String>,
+    #[serde_as(as = "Option<DisplayFromStr>")]
     fssize: Option<u64>,
+    #[serde_as(as = "Option<DisplayFromStr>")]
     fsavail: Option<u64>,
     label: Option<String>,
     partlabel: Option<String>,


### PR DESCRIPTION
While downloading the bb-imager-gui from the release page I found that I couldn't see any SD cards in the destinations menu of the program in the Linux version, this was due to the fsize & favailable fields in the output json from lsblk being output as strings but serde expecting to see numbers and panicking when unwrapping the deserialized JSON in the lsblk function

I have added a dependency on serde_with to fix this which parses the strings into an Option<u64> this seems to have fixed the issue for me and I can now see the SD cards listed again & can flash the selected SD card.

I have also updated the description method of the Device to include the "name" field as with the current implementation you often end up with empty names - this outputs the device block name (i.e. /dev/mmclk0) so if that is no good I can update it.